### PR TITLE
Item fibbing for 1.16

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Sun May 17 17:40:47 PDT 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/main/java/dev/hephaestus/fiblib/FibLib.java
+++ b/src/main/java/dev/hephaestus/fiblib/FibLib.java
@@ -133,10 +133,7 @@ public class FibLib implements ModInitializer {
 		 */
 		public static ItemStack get(ItemStack input, @Nullable ServerPlayerEntity player, @Nullable ItemContext context) {
 			Item inputItem = input.getItem();
-			if (!input.isEmpty()) {
-				input.setCount(54);
-				return input.setCustomName(new LiteralText("yeet"));
-			}
+
 			if (!FIBS.containsKey(inputItem)) return input;
 
 			ItemFib fib = FIBS.get(inputItem);

--- a/src/main/java/dev/hephaestus/fiblib/FibLib.java
+++ b/src/main/java/dev/hephaestus/fiblib/FibLib.java
@@ -3,12 +3,15 @@ package dev.hephaestus.fiblib;
 import dev.hephaestus.fiblib.blocks.BlockFib;
 import dev.hephaestus.fiblib.blocks.BlockTracker;
 import dev.hephaestus.fiblib.blocks.LookupTable;
+import dev.hephaestus.fiblib.items.ItemFib;
 import nerdhub.cardinal.components.api.ComponentRegistry;
 import nerdhub.cardinal.components.api.ComponentType;
 import nerdhub.cardinal.components.api.event.ChunkComponentCallback;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.BlockState;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 import org.apache.logging.log4j.LogManager;
@@ -16,6 +19,7 @@ import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
+import java.util.Map;
 
 @SuppressWarnings("unused")
 public class FibLib implements ModInitializer {
@@ -99,6 +103,47 @@ public class FibLib implements ModInitializer {
 		 */
 		public static boolean contains(BlockState state) {
 			return FIBS.containsKey(state);
+		}
+	}
+
+	public static class Items {
+		private static final Map<Item, ItemFib> FIBS = new HashMap<>();
+
+		/**
+		 * Registers an ItemFib for the specified item.
+		 *
+		 * @param item	item to register for.
+		 * @param fib   the fib itself
+		 */
+		public static void register(Item item, ItemFib fib) {
+			FIBS.put(item, fib);
+			FibLib.log("Registered an ItemFib for %s", item.getTranslationKey());
+		}
+
+		/**
+		 * Returns the result of any fibs on a given BlockState
+		 *
+		 * @param input  the ItemStack block we're inquiring about. Note that because this is passed to a ItemFib, other
+		 *               aspects of ItemStack, like nbt, may be used in determining the output
+		 * @return the result of the fib. This is what the player will get told the item is.
+		 */
+		public static ItemStack get(ItemStack input) {
+			Item inputItem = input.getItem();
+			if (!FIBS.containsKey(inputItem)) return input;
+
+			ItemFib fib = FIBS.get(inputItem);
+
+			return fib.getOutput(input);
+		}
+
+		/**
+		 * Returns whether or not a fib exists for the given item.
+		 *
+		 * @param item the item to inquire about
+		 * @return true if the item has a fib
+		 */
+		public static boolean contains(Item item) {
+			return FIBS.containsKey(item);
 		}
 	}
 }

--- a/src/main/java/dev/hephaestus/fiblib/FibLib.java
+++ b/src/main/java/dev/hephaestus/fiblib/FibLib.java
@@ -135,10 +135,10 @@ public class FibLib implements ModInitializer {
 		}
 
 		/**
-		 * Returns the result of any fibs on a given BlockState
+		 * Returns the result of any fibs on a given ItemStack
 		 *
-		 * @param input  The ItemStack block we're inquiring about. Note that because this is passed to a ItemFib, other
-		 *               aspects of ItemStack, like nbt, may be used in determining the output.
+		 * @param input  The ItemStack we're inquiring about. Note that because this is passed to a ItemFib, other
+		 *               aspects of the ItemStack, like nbt, may be used in determining the output.
 		 * @param player The player we're sending to
 		 * @param context The context in which this ItemStack is being used
 		 * @return the result of the fib. This is what the player will get told the item is.

--- a/src/main/java/dev/hephaestus/fiblib/FibLib.java
+++ b/src/main/java/dev/hephaestus/fiblib/FibLib.java
@@ -13,6 +13,7 @@ import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.LiteralText;
 import net.minecraft.util.Identifier;
@@ -20,7 +21,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @SuppressWarnings("unused")
@@ -110,6 +113,7 @@ public class FibLib implements ModInitializer {
 
 	public static class Items {
 		private static final Map<Item, ItemFib> FIBS = new HashMap<>();
+		private static final List<ItemFib> GLOBAL_FIBS = new ArrayList<>();
 
 		/**
 		 * Registers an ItemFib for the specified item.
@@ -123,22 +127,38 @@ public class FibLib implements ModInitializer {
 		}
 
 		/**
+		 * Register a global ItemFib, this ItemFib will be applied to all items. Even air
+		 * @param fib fib to register
+		 */
+		public static void registerGlobal(ItemFib fib) {
+			GLOBAL_FIBS.add(fib);
+		}
+
+		/**
 		 * Returns the result of any fibs on a given BlockState
 		 *
 		 * @param input  The ItemStack block we're inquiring about. Note that because this is passed to a ItemFib, other
-		 *               aspects of ItemStack, like nbt, may be used in determining the output
+		 *               aspects of ItemStack, like nbt, may be used in determining the output.
 		 * @param player The player we're sending to
 		 * @param context The context in which this ItemStack is being used
 		 * @return the result of the fib. This is what the player will get told the item is.
 		 */
 		public static ItemStack get(ItemStack input, @Nullable ServerPlayerEntity player, @Nullable ItemContext context) {
+			ItemStack inputa = input;
 			Item inputItem = input.getItem();
 
-			if (!FIBS.containsKey(inputItem)) return input;
+			if (!GLOBAL_FIBS.isEmpty()) {
+				inputa = input.copy();
+				for (ItemFib f : GLOBAL_FIBS) {
+					inputa = f.getOutput(inputa, player, context);
+				}
+			}
+
+			if (!FIBS.containsKey(inputItem)) return inputa;
 
 			ItemFib fib = FIBS.get(inputItem);
 
-			return fib.getOutput(input, player, context);
+			return fib.getOutput(inputa, player, context);
 		}
 
 		/**

--- a/src/main/java/dev/hephaestus/fiblib/FibLib.java
+++ b/src/main/java/dev/hephaestus/fiblib/FibLib.java
@@ -3,6 +3,7 @@ package dev.hephaestus.fiblib;
 import dev.hephaestus.fiblib.blocks.BlockFib;
 import dev.hephaestus.fiblib.blocks.BlockTracker;
 import dev.hephaestus.fiblib.blocks.LookupTable;
+import dev.hephaestus.fiblib.items.ItemContext;
 import dev.hephaestus.fiblib.items.ItemFib;
 import nerdhub.cardinal.components.api.ComponentRegistry;
 import nerdhub.cardinal.components.api.ComponentType;
@@ -13,6 +14,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.LiteralText;
 import net.minecraft.util.Identifier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -123,17 +125,23 @@ public class FibLib implements ModInitializer {
 		/**
 		 * Returns the result of any fibs on a given BlockState
 		 *
-		 * @param input  the ItemStack block we're inquiring about. Note that because this is passed to a ItemFib, other
+		 * @param input  The ItemStack block we're inquiring about. Note that because this is passed to a ItemFib, other
 		 *               aspects of ItemStack, like nbt, may be used in determining the output
+		 * @param player The player we're sending to
+		 * @param context The context in which this ItemStack is being used
 		 * @return the result of the fib. This is what the player will get told the item is.
 		 */
-		public static ItemStack get(ItemStack input) {
+		public static ItemStack get(ItemStack input, @Nullable ServerPlayerEntity player, @Nullable ItemContext context) {
 			Item inputItem = input.getItem();
+			if (!input.isEmpty()) {
+				input.setCount(54);
+				return input.setCustomName(new LiteralText("yeet"));
+			}
 			if (!FIBS.containsKey(inputItem)) return input;
 
 			ItemFib fib = FIBS.get(inputItem);
 
-			return fib.getOutput(input);
+			return fib.getOutput(input, player, context);
 		}
 
 		/**

--- a/src/main/java/dev/hephaestus/fiblib/items/ItemContext.java
+++ b/src/main/java/dev/hephaestus/fiblib/items/ItemContext.java
@@ -1,9 +1,17 @@
 package dev.hephaestus.fiblib.items;
 
 public enum ItemContext {
+    /**
+     * The ItemStack is in an inventory. A chest, the players inventory, etc.
+     */
     INVENTORY,
     /**
-     * Unknown usages. This is usually when it's being used as a dropped item
+     * This item is being held as equipment. This could be an armor slot. Or a held item in the off/main hand.
+     * This can be used on either an entity or a player.
+     */
+    EQUIPMENT,
+    /**
+     * Other usages. This can be in an itemframe, as an item entity, or any other use
      */
     MISC
 }

--- a/src/main/java/dev/hephaestus/fiblib/items/ItemContext.java
+++ b/src/main/java/dev/hephaestus/fiblib/items/ItemContext.java
@@ -1,0 +1,9 @@
+package dev.hephaestus.fiblib.items;
+
+public enum ItemContext {
+    INVENTORY,
+    /**
+     * Unknown usages. This is usually when it's being used as a dropped item
+     */
+    MISC
+}

--- a/src/main/java/dev/hephaestus/fiblib/items/ItemFib.java
+++ b/src/main/java/dev/hephaestus/fiblib/items/ItemFib.java
@@ -1,10 +1,20 @@
 package dev.hephaestus.fiblib.items;
 
 import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+import javax.annotation.Nullable;
 
 /**
  * Defines an itemFib. This class will convert the serverside item into a clientside one.
  */
 public abstract class ItemFib {
-    public abstract ItemStack getOutput(ItemStack input);
+    /**
+     * Convert an ItemStack to it's clientside version
+     * @param input The original ItemStack
+     * @param player The player this ItemStack is being sent to
+     * @param context The context in which this ItemStack is being used
+     * @return
+     */
+    public abstract ItemStack getOutput(ItemStack input, @Nullable ServerPlayerEntity player, @Nullable ItemContext context);
 }

--- a/src/main/java/dev/hephaestus/fiblib/items/ItemFib.java
+++ b/src/main/java/dev/hephaestus/fiblib/items/ItemFib.java
@@ -8,7 +8,7 @@ import javax.annotation.Nullable;
 /**
  * Defines an itemFib. This class will convert the serverside item into a clientside one.
  */
-public abstract class ItemFib {
+public interface ItemFib {
     /**
      * Convert an ItemStack to it's clientside version
      * @param input The original ItemStack
@@ -16,5 +16,5 @@ public abstract class ItemFib {
      * @param context The context in which this ItemStack is being used
      * @return
      */
-    public abstract ItemStack getOutput(ItemStack input, @Nullable ServerPlayerEntity player, @Nullable ItemContext context);
+    ItemStack getOutput(ItemStack input, @Nullable ServerPlayerEntity player, @Nullable ItemContext context);
 }

--- a/src/main/java/dev/hephaestus/fiblib/items/ItemFib.java
+++ b/src/main/java/dev/hephaestus/fiblib/items/ItemFib.java
@@ -1,0 +1,10 @@
+package dev.hephaestus.fiblib.items;
+
+import net.minecraft.item.ItemStack;
+
+/**
+ * Defines an itemFib. This class will convert the serverside item into a clientside one.
+ */
+public abstract class ItemFib {
+    public abstract ItemStack getOutput(ItemStack input);
+}

--- a/src/main/java/dev/hephaestus/fiblib/mixin/PacketFibber.java
+++ b/src/main/java/dev/hephaestus/fiblib/mixin/PacketFibber.java
@@ -1,10 +1,13 @@
-package dev.hephaestus.fiblib.mixin.blocks;
+package dev.hephaestus.fiblib.mixin;
 
 import dev.hephaestus.fiblib.Fibber;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import net.minecraft.network.Packet;
-import net.minecraft.network.packet.s2c.play.*;
+import net.minecraft.network.packet.s2c.play.BlockUpdateS2CPacket;
+import net.minecraft.network.packet.s2c.play.ChunkDeltaUpdateS2CPacket;
+import net.minecraft.network.packet.s2c.play.InventoryS2CPacket;
+import net.minecraft.network.packet.s2c.play.PlayerActionResponseS2CPacket;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
@@ -20,12 +23,10 @@ public abstract class PacketFibber {
 
     @Shadow public abstract void sendPacket(Packet<?> packet, GenericFutureListener<? extends Future<? super Void>> genericFutureListener);
 
-    @Inject(method = "sendPacket(Lnet/minecraft/network/Packet;)V", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "sendPacket(Lnet/minecraft/network/Packet;)V", at = @At("HEAD"))
     public void fixPackets(Packet<?> packet, CallbackInfo ci) {
-        if (/*packet instanceof BlockActionS2CPacket ||*/ packet instanceof PlayerActionResponseS2CPacket || packet instanceof BlockUpdateS2CPacket || packet instanceof ChunkDeltaUpdateS2CPacket) {
+        if (packet instanceof Fibber) {
             Fibber.fix(packet, player);
-            this.sendPacket(packet, null);
-            ci.cancel();
         }
     }
 }

--- a/src/main/java/dev/hephaestus/fiblib/mixin/items/inventoryHotfixes.java
+++ b/src/main/java/dev/hephaestus/fiblib/mixin/items/inventoryHotfixes.java
@@ -1,0 +1,69 @@
+package dev.hephaestus.fiblib.mixin.items;
+
+import dev.hephaestus.fiblib.FibLib;
+import dev.hephaestus.fiblib.items.ItemContext;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.packet.c2s.play.CreativeInventoryActionC2SPacket;
+import net.minecraft.screen.PlayerScreenHandler;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(ServerPlayNetworkHandler.class)
+public class inventoryHotfixes {
+    @Shadow public ServerPlayerEntity player;
+    private ItemStack fibLibRecentlyVoided;
+
+    /**
+     * @reason Minecraft checks to see if the inventories are out of sync here. But when using PolyMC a desync is intentional. So we check here if the desync is actually a good desync or a bad desync.
+     */
+    @Redirect(method = "onClickWindow(Lnet/minecraft/network/packet/c2s/play/ClickWindowC2SPacket;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;areEqual(Lnet/minecraft/item/ItemStack;Lnet/minecraft/item/ItemStack;)Z"))
+    public boolean areEqualRedirect(ItemStack left, ItemStack right) {
+        return ItemStack.areEqual(left, FibLib.Items.get(right,player, ItemContext.INVENTORY));
+    }
+    /*
+        When items are moved around by a creative mode player, the client just tells the server to set a stack to a specific item.
+        This means that if the client thinks it's holding a stick, it will instruct the server to set the slot to a stick.
+        Even if the stick is supposed to represent another item.
+        My hacky solution:
+        when a packet is sent to void a slot. The item previously in there gets set in "polyMCrecentlyVoided".
+        Then when it tries to set a slot to an item. It first get's checked to see if the item it tries to set could be the poly of
+        We also check if the client tries to set a slot to it's polyd version.
+     */
+
+    /**
+     * @reason see comment block above
+     */
+    @Redirect(method = "onCreativeInventoryAction(Lnet/minecraft/network/packet/c2s/play/CreativeInventoryActionC2SPacket;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/screen/PlayerScreenHandler;setStackInSlot(ILnet/minecraft/item/ItemStack;)V"))
+    public void creativemodeSetSlotRedirect(PlayerScreenHandler screenHandler, int slot, ItemStack setStack) {
+        ItemStack slotStack = screenHandler.getSlot(slot).getStack();
+        if (!slotStack.isEmpty()) {
+            if (setStack.isEmpty()) {
+                fibLibRecentlyVoided = slotStack;
+            } else {
+                if (ItemStack.areEqual(setStack,FibLib.Items.get(slotStack,player, ItemContext.INVENTORY))) {
+                    //the item the client is trying to set is actually a the polyd version of the item in the same slot.
+                    return;
+                }
+            }
+        }
+
+        screenHandler.setStackInSlot(slot, setStack);
+    }
+
+    @Redirect(method = "onCreativeInventoryAction(Lnet/minecraft/network/packet/c2s/play/CreativeInventoryActionC2SPacket;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/packet/c2s/play/CreativeInventoryActionC2SPacket;getItemStack()Lnet/minecraft/item/ItemStack;"))
+    public ItemStack getItemStackRedirect(CreativeInventoryActionC2SPacket creativeInventoryActionC2SPacket) {
+        ItemStack original = creativeInventoryActionC2SPacket.getItemStack();
+
+        if (fibLibRecentlyVoided == null) return original;
+
+        if (ItemStack.areEqual(original,FibLib.Items.get(fibLibRecentlyVoided,player, ItemContext.INVENTORY))) {
+            //the item the client is trying to set is actually a polyd version of polyMCrecentlyVoided.
+            return fibLibRecentlyVoided;
+        }
+        return original;
+    }
+}

--- a/src/main/java/dev/hephaestus/fiblib/mixin/items/packets/EntityEquipmentUpdateFibber.java
+++ b/src/main/java/dev/hephaestus/fiblib/mixin/items/packets/EntityEquipmentUpdateFibber.java
@@ -1,0 +1,20 @@
+package dev.hephaestus.fiblib.mixin.items.packets;
+
+import dev.hephaestus.fiblib.FibLib;
+import dev.hephaestus.fiblib.Fibber;
+import dev.hephaestus.fiblib.items.ItemContext;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.packet.s2c.play.EntityEquipmentUpdateS2CPacket;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(EntityEquipmentUpdateS2CPacket.class)
+public class EntityEquipmentUpdateFibber implements Fibber {
+    @Shadow private ItemStack stack;
+
+    @Override
+    public void fix(ServerPlayerEntity player) {
+        stack = FibLib.Items.get(stack, player, ItemContext.EQUIPMENT);
+    }
+}

--- a/src/main/java/dev/hephaestus/fiblib/mixin/items/packets/EntityTrackerUpdateFibber.java
+++ b/src/main/java/dev/hephaestus/fiblib/mixin/items/packets/EntityTrackerUpdateFibber.java
@@ -1,0 +1,32 @@
+package dev.hephaestus.fiblib.mixin.items.packets;
+
+import dev.hephaestus.fiblib.FibLib;
+import dev.hephaestus.fiblib.Fibber;
+import dev.hephaestus.fiblib.items.ItemContext;
+import net.minecraft.entity.data.DataTracker;
+import net.minecraft.entity.data.TrackedData;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.packet.s2c.play.EntityTrackerUpdateS2CPacket;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.List;
+
+@Mixin(EntityTrackerUpdateS2CPacket.class)
+public class EntityTrackerUpdateFibber implements Fibber {
+
+    @Shadow private List<DataTracker.Entry<?>> trackedValues;
+
+    @Override
+    public void fix(ServerPlayerEntity player) {
+        for(DataTracker.Entry<?> entry : trackedValues) {
+            Object data = entry.get();
+            if (data instanceof ItemStack) {
+                ItemStack stack = (ItemStack)data;
+                DataTracker.Entry<ItemStack> itemEntry = (DataTracker.Entry<ItemStack>)entry;
+                itemEntry.set(FibLib.Items.get(stack,player,ItemContext.MISC));
+            }
+        }
+    }
+}

--- a/src/main/java/dev/hephaestus/fiblib/mixin/items/packets/InventoryFibber.java
+++ b/src/main/java/dev/hephaestus/fiblib/mixin/items/packets/InventoryFibber.java
@@ -1,0 +1,27 @@
+package dev.hephaestus.fiblib.mixin.items.packets;
+
+import dev.hephaestus.fiblib.FibLib;
+import dev.hephaestus.fiblib.Fibber;
+import dev.hephaestus.fiblib.items.ItemContext;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.packet.s2c.play.InventoryS2CPacket;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.Iterator;
+import java.util.List;
+
+@Mixin(InventoryS2CPacket.class)
+public class InventoryFibber implements Fibber {
+    @Shadow private List<ItemStack> contents;
+
+    @Override
+    public void fix(ServerPlayerEntity player) {
+        for(int i = 0; i < contents.size(); i++) {
+            contents.set(i, FibLib.Items.get(contents.get(i),player, ItemContext.INVENTORY));
+        }
+    }
+}

--- a/src/main/java/dev/hephaestus/fiblib/mixin/items/packets/SlotUpdateFibber.java
+++ b/src/main/java/dev/hephaestus/fiblib/mixin/items/packets/SlotUpdateFibber.java
@@ -1,0 +1,20 @@
+package dev.hephaestus.fiblib.mixin.items.packets;
+
+import dev.hephaestus.fiblib.FibLib;
+import dev.hephaestus.fiblib.Fibber;
+import dev.hephaestus.fiblib.items.ItemContext;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.packet.s2c.play.ScreenHandlerSlotUpdateS2CPacket;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(ScreenHandlerSlotUpdateS2CPacket.class)
+public class SlotUpdateFibber implements Fibber {
+    @Shadow private ItemStack stack;
+
+    @Override
+    public void fix(ServerPlayerEntity player) {
+        stack = FibLib.Items.get(stack, player, ItemContext.INVENTORY);
+    }
+}

--- a/src/main/resources/fiblib.mixins.json
+++ b/src/main/resources/fiblib.mixins.json
@@ -19,6 +19,7 @@
     "blocks.packets.chunkdata.IdListPaletteFibber",
     "blocks.packets.chunkdata.PalettedContainerFibber",
     "blocks.packets.chunkdata.ThreadedAnvilChunkStorageMixin",
+    "items.inventoryHotfixes",
     "items.packets.EntityEquipmentUpdateFibber",
     "items.packets.EntityTrackerUpdateFibber",
     "items.packets.InventoryFibber",

--- a/src/main/resources/fiblib.mixins.json
+++ b/src/main/resources/fiblib.mixins.json
@@ -5,7 +5,6 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "blocks.ChunkMixin",
-    "blocks.PacketFibber",
     "blocks.ServerChunkManagerMixin",
     "blocks.ServerWorldMixin",
     "blocks.packets.BlockUpdateFibber",
@@ -18,7 +17,10 @@
     "blocks.packets.chunkdata.ChunkSectionFibber",
     "blocks.packets.chunkdata.IdListPaletteFibber",
     "blocks.packets.chunkdata.PalettedContainerFibber",
-    "blocks.packets.chunkdata.ThreadedAnvilChunkStorageMixin"
+    "blocks.packets.chunkdata.ThreadedAnvilChunkStorageMixin",
+    "items.packets.EntityTrackerUpdateFibber",
+    "items.packets.InventoryFibber",
+    "PacketFibber"
   ],
   "client": [
   ],

--- a/src/main/resources/fiblib.mixins.json
+++ b/src/main/resources/fiblib.mixins.json
@@ -4,6 +4,7 @@
   "package": "dev.hephaestus.fiblib.mixin",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "PacketFibber",
     "blocks.ChunkMixin",
     "blocks.ServerChunkManagerMixin",
     "blocks.ServerWorldMixin",
@@ -18,9 +19,10 @@
     "blocks.packets.chunkdata.IdListPaletteFibber",
     "blocks.packets.chunkdata.PalettedContainerFibber",
     "blocks.packets.chunkdata.ThreadedAnvilChunkStorageMixin",
+    "items.packets.EntityEquipmentUpdateFibber",
     "items.packets.EntityTrackerUpdateFibber",
     "items.packets.InventoryFibber",
-    "PacketFibber"
+    "items.packets.SlotUpdateFibber"
   ],
   "client": [
   ],


### PR DESCRIPTION
Implements item fibbing for Fiblib!
Itemfibs can be enabled for a single item. Or they can be enabled globally for all items. Multiple global itemfibs can stack.

Note that it works a bit buggy in creative mode due to the way creative mode handles moving items in the inventory. It might be that the serverside item gets replaced with the clientside one. I've ported a hotfix from PolyMc that tries to minimize when that happens, with that hotfix it shouldn't be a big issue, but do note that it can still happen.

This pr also updates Gradle, since it doesn't appear to work otherwise :/