### PR TITLE
Add Block Delta + Loot Table fibbing + Jitpack build script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.8-SNAPSHOT'
+	id 'fabric-loom' version '0.9-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ yarn_mappings       = 1.17+build.10
 loader_version      = 0.11.6
 
 # Mod Properties
-mod_version         = 1.1.0+1.17
+mod_version         = 1.2.0+1.17
 maven_group         = dev.hephaestus
 archives_base_name  = FibLib
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,5 @@
+before_install:
+  - export SDKMAN_DIR="/home/jitpack/sdkman" && curl -s "https://get.sdkman.io" | bash
+  - source "/home/jitpack/sdkman/bin/sdkman-init.sh"
+  - sdk install java 16.0.1.hs-adpt
+  - sdk use java 16.0.1.hs-adpt

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -3,3 +3,4 @@ before_install:
   - source "/home/jitpack/sdkman/bin/sdkman-init.sh"
   - sdk install java 16.0.1.hs-adpt
   - sdk use java 16.0.1.hs-adpt
+  

--- a/src/main/java/dev/hephaestus/fiblib/api/BlockFib.java
+++ b/src/main/java/dev/hephaestus/fiblib/api/BlockFib.java
@@ -25,6 +25,17 @@ public interface BlockFib {
     boolean isLenient();
 
     /**
+     * Whether this BlockFib modifies the drops of fibbed states.
+     *
+     * <p>
+     * If this method returns {@code true}, and a player mines state A fibbed as state B,
+     * the loot of state B will be dropped instead of the default state A loot.
+     *
+     * @return {@code true} if this BlockFib should modify the drops of fibbed states
+     */
+    boolean modifiesDrops();
+
+    /**
      * Gets the list of states this block fib applies to.
      *
      * This list should not change throughout a fibs life.
@@ -62,29 +73,30 @@ public interface BlockFib {
         private final BiFunction<@Nullable Predicate<ServerPlayerEntity>, Boolean, BlockFib> constructor;
         private Predicate<ServerPlayerEntity> condition = null;
         private boolean lenient = false;
+        private boolean modifiesDrops = false;
 
         public Builder(Block inputBlock, Block outputBlock) {
             this.constructor = (condition, lenient) -> condition == null
-                    ? new BlockFibImpl(inputBlock, outputBlock, lenient)
-                    : new BlockFibImpl.Conditional(inputBlock, outputBlock, lenient, condition);
+                    ? new BlockFibImpl(inputBlock, outputBlock, lenient, modifiesDrops)
+                    : new BlockFibImpl.Conditional(inputBlock, outputBlock, lenient, modifiesDrops, condition);
         }
 
         public Builder(BlockState inputState, BlockState outputState) {
             this.constructor = (condition, lenient) -> condition == null
-                    ? new BlockStateFib(inputState, outputState, lenient)
-                    : new BlockStateFib.Conditional(inputState, outputState, lenient, condition);
+                    ? new BlockStateFib(inputState, outputState, lenient, modifiesDrops)
+                    : new BlockStateFib.Conditional(inputState, outputState, lenient, modifiesDrops, condition);
         }
 
         public Builder(Block inputBlock, BlockState outputState) {
             this.constructor = (condition, lenient) -> condition == null
-                    ? new BlockFibImpl(inputBlock, outputState, lenient)
-                    : new BlockFibImpl.Conditional(inputBlock, outputState, lenient, condition);
+                    ? new BlockFibImpl(inputBlock, outputState, lenient, modifiesDrops)
+                    : new BlockFibImpl.Conditional(inputBlock, outputState, lenient, modifiesDrops, condition);
         }
 
         public Builder(BlockState inputState, Block outputBlock) {
             this.constructor = (condition, lenient) -> condition == null
-                    ? new BlockStateFib(inputState, outputBlock.getDefaultState(), lenient)
-                    : new BlockStateFib.Conditional(inputState, outputBlock.getDefaultState(), lenient, condition);
+                    ? new BlockStateFib(inputState, outputBlock.getDefaultState(), lenient, modifiesDrops)
+                    : new BlockStateFib.Conditional(inputState, outputBlock.getDefaultState(), lenient, modifiesDrops, condition);
         }
 
         public Builder withCondition(Predicate<ServerPlayerEntity> condition) {
@@ -94,6 +106,11 @@ public interface BlockFib {
 
         public Builder lenient() {
             this.lenient = true;
+            return this;
+        }
+
+        public Builder modifiesDrops() {
+            this.modifiesDrops = true;
             return this;
         }
 

--- a/src/main/java/dev/hephaestus/fiblib/impl/BlockFibImpl.java
+++ b/src/main/java/dev/hephaestus/fiblib/impl/BlockFibImpl.java
@@ -14,22 +14,29 @@ public class BlockFibImpl implements BlockFib {
     private final Block inputBlock;
     private final BlockState outputState;
     private final boolean lenient;
+    private final boolean modifiesDrops;
     private final ImmutableList<BlockState> inputs;
 
-    public BlockFibImpl(Block inputBlock, BlockState outputState, boolean lenient) {
+    public BlockFibImpl(Block inputBlock, BlockState outputState, boolean lenient, boolean modifiesDrops) {
         this.inputBlock = inputBlock;
         this.outputState = outputState;
         this.inputs = inputBlock.getStateManager().getStates();
         this.lenient = lenient;
+        this.modifiesDrops = modifiesDrops;
     }
 
-    public BlockFibImpl(Block inputBlock, Block outputBlock, boolean lenient) {
-        this(inputBlock, outputBlock.getDefaultState(), lenient);
+    public BlockFibImpl(Block inputBlock, Block outputBlock, boolean lenient, boolean modifiesDrops) {
+        this(inputBlock, outputBlock.getDefaultState(), lenient, modifiesDrops);
     }
 
     @Override
     public final boolean isLenient() {
         return this.lenient;
+    }
+
+    @Override
+    public final boolean modifiesDrops() {
+        return this.modifiesDrops;
     }
 
     @Override
@@ -45,12 +52,12 @@ public class BlockFibImpl implements BlockFib {
     public static class Conditional extends BlockFibImpl {
         private final Predicate<@Nullable ServerPlayerEntity> condition;
 
-        public Conditional(Block inputBlock, Block outputBlock, boolean lenient, Predicate<@Nullable ServerPlayerEntity> condition) {
-            this(inputBlock, outputBlock.getDefaultState(), lenient, condition);
+        public Conditional(Block inputBlock, Block outputBlock, boolean lenient, boolean modifiesDrops, Predicate<@Nullable ServerPlayerEntity> condition) {
+            this(inputBlock, outputBlock.getDefaultState(), lenient, modifiesDrops, condition);
         }
 
-        public Conditional(Block inputBlock, BlockState outputState, boolean lenient, Predicate<@Nullable ServerPlayerEntity> condition) {
-            super(inputBlock, outputState, lenient);
+        public Conditional(Block inputBlock, BlockState outputState, boolean lenient, boolean modifiesDrops, Predicate<@Nullable ServerPlayerEntity> condition) {
+            super(inputBlock, outputState, modifiesDrops, lenient);
             this.condition = condition;
         }
 

--- a/src/main/java/dev/hephaestus/fiblib/impl/BlockStateFib.java
+++ b/src/main/java/dev/hephaestus/fiblib/impl/BlockStateFib.java
@@ -14,17 +14,24 @@ public class BlockStateFib implements BlockFib {
     private final BlockState outputState;
     private final ImmutableList<BlockState> inputStates;
     private final boolean lenient;
+    private final boolean modifiesDrops;
 
-    public BlockStateFib(BlockState inputState, BlockState outputState, boolean lenient) {
+    public BlockStateFib(BlockState inputState, BlockState outputState, boolean lenient, boolean modifiesDrops) {
         this.inputState = inputState;
         this.outputState = outputState;
         this.inputStates = ImmutableList.of(inputState);
         this.lenient = lenient;
+        this.modifiesDrops = modifiesDrops;
     }
 
     @Override
     public final boolean isLenient() {
         return this.lenient;
+    }
+
+    @Override
+    public final boolean modifiesDrops() {
+        return this.modifiesDrops;
     }
 
     @Override
@@ -40,8 +47,8 @@ public class BlockStateFib implements BlockFib {
     public static class Conditional extends BlockStateFib {
         private final Predicate<@Nullable ServerPlayerEntity> condition;
 
-        public Conditional(BlockState inputState, BlockState outputState, boolean lenient, Predicate<@Nullable ServerPlayerEntity> condition) {
-            super(inputState, outputState, lenient);
+        public Conditional(BlockState inputState, BlockState outputState, boolean lenient, boolean modifiesBlocks, Predicate<@Nullable ServerPlayerEntity> condition) {
+            super(inputState, outputState, lenient, modifiesBlocks);
             this.condition = condition;
         }
 

--- a/src/main/java/dev/hephaestus/fiblib/mixin/block/AbstractBlockStateMixin.java
+++ b/src/main/java/dev/hephaestus/fiblib/mixin/block/AbstractBlockStateMixin.java
@@ -1,0 +1,31 @@
+package dev.hephaestus.fiblib.mixin.block;
+
+import dev.hephaestus.fiblib.api.BlockFibRegistry;
+import net.minecraft.block.AbstractBlock;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.BlockView;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(AbstractBlock.AbstractBlockState.class)
+public abstract class AbstractBlockStateMixin {
+
+    @Shadow protected abstract BlockState asBlockState();
+
+    @Inject(
+            method = "calcBlockBreakingDelta",
+            at = @At("HEAD"), cancellable = true)
+    private void onCalculateDelta(PlayerEntity player, BlockView world, BlockPos pos, CallbackInfoReturnable<Float> cir) {
+        if(world instanceof ServerWorld) {
+            BlockState newState = BlockFibRegistry.getBlockState(asBlockState(), (ServerPlayerEntity) player);
+            cir.setReturnValue(newState.getBlock().calcBlockBreakingDelta(newState, player, world, pos));
+        }
+    }
+}

--- a/src/main/java/dev/hephaestus/fiblib/mixin/block/BlockDropMixin.java
+++ b/src/main/java/dev/hephaestus/fiblib/mixin/block/BlockDropMixin.java
@@ -1,0 +1,48 @@
+package dev.hephaestus.fiblib.mixin.block;
+
+import dev.hephaestus.fiblib.api.BlockFibRegistry;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.entity.Entity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+
+@Mixin(Block.class)
+public abstract class BlockDropMixin {
+
+    @Shadow public static List<ItemStack> getDroppedStacks(BlockState state, ServerWorld world, BlockPos pos, @Nullable BlockEntity blockEntity, @Nullable Entity entity, ItemStack stack) { return null; }
+    @Shadow public static void dropStack(World world, BlockPos pos, ItemStack stack) { }
+
+    @Inject(
+            method = "dropStacks(Lnet/minecraft/block/BlockState;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/entity/BlockEntity;Lnet/minecraft/entity/Entity;Lnet/minecraft/item/ItemStack;)V",
+            at = @At("HEAD"),
+            cancellable = true)
+    private static void beforeDrop(BlockState state, World world, BlockPos pos, BlockEntity blockEntity, Entity entity, ItemStack stack, CallbackInfo ci) {
+        if(world instanceof ServerWorld && entity instanceof ServerPlayerEntity) {
+            BlockState newState = BlockFibRegistry.getBlockState(state, (ServerPlayerEntity) entity);
+
+            // If the states do not match (currently being fibbed), cancel the original drop & drop the new loot table instead.
+            if(newState != state) {
+                List<ItemStack> dropped = getDroppedStacks(newState, (ServerWorld) world, pos, blockEntity, entity, stack);
+                if(dropped != null) {
+                    dropped.forEach((itemStack) -> dropStack(world, pos, itemStack));
+                    newState.onStacksDropped((ServerWorld) world, pos, stack);
+                }
+
+                ci.cancel();
+            }
+        }
+    }
+}

--- a/src/main/resources/fiblib.mixins.json
+++ b/src/main/resources/fiblib.mixins.json
@@ -11,6 +11,7 @@
     "MixinServerPlayNetworkHandler",
     "TACSAccessor",
     "block.AbstractBlockStateMixin",
+    "block.BlockDropMixin",
     "packets.MixinBlockUpdateS2CPacket",
     "packets.MixinPlayerActionResponseS2CPacket",
     "packets.chunkdata.MixinArrayPalette",

--- a/src/main/resources/fiblib.mixins.json
+++ b/src/main/resources/fiblib.mixins.json
@@ -10,6 +10,7 @@
     "MixinMinecraftServer",
     "MixinServerPlayNetworkHandler",
     "TACSAccessor",
+    "block.AbstractBlockStateMixin",
     "packets.MixinBlockUpdateS2CPacket",
     "packets.MixinPlayerActionResponseS2CPacket",
     "packets.chunkdata.MixinArrayPalette",


### PR DESCRIPTION
This PR contains my small local changes on the library:
1. Block Delta fibbing, which is required to prevent speed desync when the client is being shown a block with a different delta from the server. 
2. Block Drop fibbing - if the player mines stone fibbed as a Diamond Ore, it will use the Diamond Ore drop table. I'm thinking it would be nice to provide a property in block fibs to be able to toggle this feature.

I have tested both of these features fairly extensively in personal projects that depend on FibLib.

\+ Jitpack.yml for building & a Fabric Loom version bump to 0.9.